### PR TITLE
Replace open() with spawn() to avoid antivirus false positives

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,6 @@
-import {execFileSync} from "child_process";
+import {execFileSync, spawn} from "child_process";
 import path from "path";
 import {fileURLToPath} from "url";
-import { spawn } from "child_process";
 
 import open from "../node_modules/open/index.js";
 //import {error} from "console";
@@ -30,8 +29,8 @@ if (method === "query") {
 } else if (method === "startTimer") {
     //error([process.argv[2], parameters]); //for debugging
     const child = spawn(hourglassExe, parameters, {
-      detached: true,
-      stdio: "ignore",
+        detached: true,
+        stdio: "ignore",
     });
     child.unref();
 } else if (method === "showHelp") {

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,7 @@
 import {execFileSync} from "child_process";
 import path from "path";
 import {fileURLToPath} from "url";
+import { spawn } from "child_process";
 
 import open from "../node_modules/open/index.js";
 //import {error} from "console";
@@ -28,7 +29,11 @@ if (method === "query") {
     }
 } else if (method === "startTimer") {
     //error([process.argv[2], parameters]); //for debugging
-    open(hourglassExe, {app: {arguments: parameters}});
+    const child = spawn(hourglassExe, parameters, {
+      detached: true,
+      stdio: "ignore",
+    });
+    child.unref();
 } else if (method === "showHelp") {
     open(path.resolve(__dirname, "help", "help.html"));
 }


### PR DESCRIPTION
## 🛠 Description

This PR replaces the use of the `open` package with the `spawn` method when launching `Hourglass.exe`.

The motivation for this change is that **Avast antivirus was detecting and blocking the plugin at runtime**, specifically flagging it with:

> `IDP.HELU.PSE46 - Command line detection`  
> Triggered by `powershell.exe` during process launch

Upon investigation, the issue appears to stem from how `open` internally uses PowerShell or CMD to launch applications, which can trigger false positives in behaviour-based antivirus systems.

---

## ✅ What Changed

- Replaced `open()` with `spawn()` for launching `Hourglass.exe` in the `startTimer` method
- Added `detached: true` and `stdio: "ignore"` to allow Hourglass to run independently without blocking the plugin
- Verified that this change **prevents the antivirus detection issue**

---

Resolves #9